### PR TITLE
Fix rbenv init permission error in zshrc

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -298,6 +298,6 @@ fi
 # rbenv (only if installed)
 # ---------------------------------------------------------------------
 if command -v rbenv >/dev/null 2>&1; then
-  export RBENV_ROOT=/usr/local/var/rbenv
+  export RBENV_ROOT="${RBENV_ROOT:-$HOME/.rbenv}"
   eval "$(rbenv init -)"
 fi


### PR DESCRIPTION
## Summary
- avoid trying to create `/usr/local/var` when rbenv is loaded
- use `$HOME/.rbenv` as default `RBENV_ROOT` if the variable is unset

## Testing
- `zsh -n zshrc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bf38483dc8332ad6e1bd48ef51bb1